### PR TITLE
Create non-existent instances

### DIFF
--- a/cache_toolbox/relation.py
+++ b/cache_toolbox/relation.py
@@ -22,9 +22,15 @@ Usage
 
         name = models.CharField(max_length=20)
 
-    cache_relation(User.foo)
+    cache_relation(User.foo, create=True, defaults={})
 
 (``primary_key`` being ``True`` is currently required.)
+
+With ``create=True`` we force the creation of an instance of `Foo` in case that
+we are trying to access to user.foo_cache but ``user.foo`` doesn't exist yet.
+
+If ``create=True`` we are going to pass the default to the get_or_create
+function.
 
 ::
 
@@ -76,7 +82,8 @@ from django.db.models.signals import post_save, post_delete
 
 from .core import get_instance, delete_instance
 
-def cache_relation(descriptor, timeout=None):
+
+def cache_relation(descriptor, timeout=None, create=False, defaults=None):
     rel = descriptor.related
     related_name = '%s_cache' % rel.field.related_query_name()
 
@@ -94,7 +101,9 @@ def cache_relation(descriptor, timeout=None):
         except AttributeError:
             pass
 
-        instance = get_instance(rel.model, self.pk, timeout)
+        instance = get_instance(
+            rel.model, self.pk, timeout, create=create, defaults=defaults
+        )
 
         setattr(self, '_%s_cache' % related_name, instance)
 


### PR DESCRIPTION
It's possible that the object related with the cache model that we are
trying to access doesn't exist yet.

If we had created our caching model with create=True, example:

```
cache_relation(User.settings, create=True)
```

the instance for User.settings is going to be created in caste that it
was not found.

Added some spaces to be Flake8 compliant.
